### PR TITLE
Added showFooter option

### DIFF
--- a/addon/mixins/table.js
+++ b/addon/mixins/table.js
@@ -23,6 +23,7 @@ export default Ember.Mixin.create({
     nowrapTable: true,
     tableStriped: false,
     rowSelectionHandler: null,
+    showFooter: true,
 
     layout: Ember.computed(function() {
         return Ember.HTMLBars.compile('{{yield}}{{#eb-table-content}}{{eb-table-header}}{{eb-table-body}}{{eb-table-footer}}{{/eb-table-content}}');
@@ -92,6 +93,18 @@ export default Ember.Mixin.create({
 
     willDestroyElement: function() {
 
+    },
+
+    init(){
+      this._super();
+
+      let showFooter = get(this, 'showFooter');
+      if (!showFooter){
+          let layout = Ember.computed(function() {
+          return Ember.HTMLBars.compile('{{yield}}{{#eb-table-content}}{{eb-table-header}}{{eb-table-body}}{{!eb-table-footer}}{{/eb-table-content}}');
+      });
+      set(this, 'layout', layout);
+      }
     }
 
 });


### PR DESCRIPTION
If showFooter is false then the pagination table footer will not render:

``` html
    {{#eb-table
        showFooter=false
        content=users
        pageSize=100
        columns=columns1}}
    {{/eb-table}}
```

![eb-table](https://cloud.githubusercontent.com/assets/10543911/16174783/845f0e06-3590-11e6-995d-0f626916278b.png)
